### PR TITLE
스프링 1차 refactoring 

### DIFF
--- a/src/main/java/com/api/post/controller/PostController.java
+++ b/src/main/java/com/api/post/controller/PostController.java
@@ -2,14 +2,11 @@ package com.api.post.controller;
 
 import com.api.post.dto.PostRequestDto;
 import com.api.post.dto.PostResponseDto;
-import com.api.post.entity.Post;
 import com.api.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.security.auth.login.CredentialException;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/api/post/controller/PostController.java
+++ b/src/main/java/com/api/post/controller/PostController.java
@@ -15,41 +15,28 @@ import java.util.List;
 public class PostController {
     private final PostService postService;
     @GetMapping("/posts")
-    public ResponseEntity<Object> getPosts(){
-        return
-                ResponseEntity.ok(postService.getPosts());
+    public List<PostResponseDto> getPosts(){
+        return postService.getPosts();
     }
 
     @PostMapping("/posts")
-    public ResponseEntity<Object> createPost(@RequestBody PostRequestDto postRequestDto){
-        return ResponseEntity.ok(new PostResponseDto(postService.createPost(postRequestDto)));
+    @ResponseStatus(HttpStatus.CREATED)
+    public PostResponseDto createPost(@RequestBody PostRequestDto postRequestDto){
+        return postService.createPost(postRequestDto);
     }
 
     @GetMapping("/posts/{id}")
-    public ResponseEntity<Object> getPost(@PathVariable Long id){
-        try{
-        return ResponseEntity.ok(new PostResponseDto(postService.getPost(id)));
-        }catch (IllegalArgumentException e){
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    public PostResponseDto getPost(@PathVariable Long id){
+        return postService.getPost(id);
     }
 
     @PutMapping("/posts/{id}")
-    public ResponseEntity<Object> updatePost(@PathVariable Long id, @RequestBody PostRequestDto postRequestDto){
-        try{
-            return ResponseEntity.ok(new PostResponseDto(postService.updatePost(id, postRequestDto)));
-        }catch (IllegalArgumentException | CredentialException e){
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    public PostResponseDto updatePost(@PathVariable Long id, @RequestBody PostRequestDto postRequestDto){
+        return postService.updatePost(id, postRequestDto);
     }
 
     @DeleteMapping("/posts/{id}")
-    public ResponseEntity<Object> deletePost(@PathVariable Long id, @RequestBody PostRequestDto postRequestDto){
-        try{
-            postService.deletePost(id, postRequestDto);
-            return ResponseEntity.ok("delete complete");
-        }catch (IllegalArgumentException | CredentialException e){
-            return ResponseEntity.badRequest().body("delete fail : " + e.getMessage());
-        }
+    public void deletePost(@PathVariable Long id, @RequestBody PostRequestDto postRequestDto){
+        postService.deletePost(id, postRequestDto);
     }
 }

--- a/src/main/java/com/api/post/dto/ExceptionResponseDto.java
+++ b/src/main/java/com/api/post/dto/ExceptionResponseDto.java
@@ -1,0 +1,15 @@
+package com.api.post.dto;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ExceptionResponseDto {
+    private final HttpStatus status;
+    private final String message;
+
+    public ExceptionResponseDto(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/api/post/dto/PostRequestDto.java
+++ b/src/main/java/com/api/post/dto/PostRequestDto.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
 public class PostRequestDto {
     private String title;
     private String writer;

--- a/src/main/java/com/api/post/dto/PostResponseDto.java
+++ b/src/main/java/com/api/post/dto/PostResponseDto.java
@@ -7,12 +7,11 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
 public class PostResponseDto {
-    private String title;
-    private String writer;
-    private String contents;
-    private LocalDateTime modifiedAt;
+    private final String title;
+    private final String writer;
+    private final String contents;
+    private final LocalDateTime modifiedAt;
 
     public PostResponseDto(Post post) {
         this.title = post.getTitle();

--- a/src/main/java/com/api/post/entity/Post.java
+++ b/src/main/java/com/api/post/entity/Post.java
@@ -35,5 +35,5 @@ public class Post extends Timestamped{
 
     public void updateContents(String contents) {this.contents = contents;}
 
-    public boolean isValidPassword(String comparePassword) {return this.password.equals(comparePassword);}
+    public boolean isPasswordValid(String comparePassword) {return !this.password.equals(comparePassword);}
 }

--- a/src/main/java/com/api/post/exception/ExceptionController.java
+++ b/src/main/java/com/api/post/exception/ExceptionController.java
@@ -1,0 +1,26 @@
+package com.api.post.exception;
+
+import com.api.post.dto.ExceptionResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionController {
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ExceptionResponseDto IllegalArgumentException(Exception e){
+        return new ExceptionResponseDto(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ExceptionResponseDto HttpMessageNotReadableException(Exception e){
+        return new ExceptionResponseDto(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ExceptionResponseDto HttpRequestMethodNotSupportedException(Exception e){
+        return new ExceptionResponseDto(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+}

--- a/src/main/java/com/api/post/service/PostService.java
+++ b/src/main/java/com/api/post/service/PostService.java
@@ -15,44 +15,45 @@ public class PostService {
     private final PostRepository postRepository;
 
     @Transactional(readOnly = true)
-    public List<Post> getPosts() {
-        return postRepository.findAllByOrderByModifiedAtDesc();
+    public List<PostResponseDto> getPosts() {
+        return postRepository.findAllByOrderByModifiedAtDesc().stream().map(PostResponseDto::new).collect(Collectors.toList());
     }
 
     @Transactional
-    public Post createPost(PostRequestDto postRequestDto) {
+    public PostResponseDto createPost(PostRequestDto postRequestDto) {
         Post post = new Post(postRequestDto);
         postRepository.save(post);
-        return post;
+        return new PostResponseDto(post);
     }
 
     @Transactional(readOnly = true)
-    public Post getPost(Long id) {
-        return postRepository.findById(id).orElseThrow(
+    public PostResponseDto getPost(Long id) {
+        return new PostResponseDto(postRepository.findById(id).orElseThrow(
                 () -> new IllegalArgumentException("게시물이 없습니다.")
-        );
+        ));
     }
 
     @Transactional
-    public Post updatePost(Long id, PostRequestDto postRequestDto) throws IllegalArgumentException {
+    public PostResponseDto updatePost(Long id, PostRequestDto postRequestDto){
         Post post = postRepository.findById(id).orElseThrow(
                 () -> new IllegalArgumentException("해당되는 게시물이 존재하지 않습니다."));
 
-        if(!post.isValidPassword(postRequestDto.getPassword())){
+        if(post.isPasswordValid(postRequestDto.getPassword())){
             throw new IllegalArgumentException("패스워드가 일치하지 않습니다.");
         }
 
         post.updateContents(postRequestDto.getContents());
         postRepository.save(post);
-        return post;
+
+        return new PostResponseDto(post);
     }
 
     @Transactional
-    public void deletePost(Long id, PostRequestDto postRequestDto) throws IllegalArgumentException{
+    public void deletePost(Long id, PostRequestDto postRequestDto){
         Post post = postRepository.findById(id).orElseThrow(
                 () -> new IllegalArgumentException("해당되는 게시물이 존재하지 않습니다."));
 
-        if(!post.isValidPassword(postRequestDto.getPassword())){
+        if(post.isPasswordValid(postRequestDto.getPassword())){
             throw new IllegalArgumentException("패스워드가 일치하지 않습니다.");
         }
 

--- a/src/main/java/com/api/post/service/PostService.java
+++ b/src/main/java/com/api/post/service/PostService.java
@@ -1,6 +1,7 @@
 package com.api.post.service;
 
 import com.api.post.dto.PostRequestDto;
+import com.api.post.dto.PostResponseDto;
 import com.api.post.entity.Post;
 import com.api.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
**1. Controller**
- 기존 `ResponseEntity<Object>` 를 반환하는 형태에서, `PostResponseDto` 를 반환하는 식으로 변경했습니다. 
   - `@RestController` 가 return 된 값을 response body에 넣어주는 사실을 알게되었고, 굳이 `ResponseEntity`를 사용 할 이유가 없다고 판단했습니다.
- `@RestControllerAdvice` 를 사용하여, `try-catch` 문을 사용하지 않고, 에러를 핸들링 할 수 있도록 설정했습니다.
   - return 포맷이 모두 같기에, 처음에는 `RuntimeException`로 묶어서 할까 고민했습니다, 하지만, 각각이 어떤 에러를 반환하는지 구체적으로 명시하는 것이 더 좋겠다는 판단을 하여 분리시켜놓았습니다.
   - 추후, exception type과 code를 더 디테일하게 나눠보고 싶습니다.
- 예외상황에서 `ExceptionResponseDto`를 반환하도록 했습니다.
   - 요청의 성공과 실패에 대한 구분을 좀더 명확히 짓고 싶었습니다. ( ex: 성공시에는 `PostResponseDto`, 실패시에는 `ExceptionResponseDto`)
- DELETE 시 `void` 를 리턴타입으로 선언하여, 성공 시 코드만 보여질 수 있게 했습니다.
   - 의미없는 결과값을 내지 않기 위해서 `void`를 return 하였습니다.  
  
**2. Service**
- `CredentialException` 을 제거하고 `IllegalArgumentException` 을 사용하였습니다.
   - 해당 예외가 인증에 대한 것이기 때문에, 본래의 의도와 제가 사용하고자하는 목적이 일치하지 않음을 깨달았습니다.
- `validation` 을 `Service`내에서 `equels` 를 이용해서 하지않고, `Entity`가 하도록 했습니다.
   - 해당 `validation`은 데이터를 가지고 있는 `Entity`의 역할이라고 판단했습니다.

**3. DTO**
- 의미없는 `Setter`를 제거하여 사용하지 않도록 했습니다.